### PR TITLE
Add support to EntityExplodeEvent of Bukkit

### DIFF
--- a/src/keepcalm/mods/bukkit/asm/replacements/Explosion_BukkitForge.java
+++ b/src/keepcalm/mods/bukkit/asm/replacements/Explosion_BukkitForge.java
@@ -1,0 +1,142 @@
+package keepcalm.mods.bukkit.asm.replacements;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import keepcalm.mods.events.EventFactory;
+
+import com.eoware.asm.asmagic.AsmagicReplaceMethod;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.MathHelper;
+import net.minecraft.world.ChunkPosition;
+import net.minecraft.world.Explosion;
+import net.minecraft.world.World;
+
+public class Explosion_BukkitForge
+{
+    public boolean a = false; //isFlaming
+    public boolean b = true; //isSmoking
+    private int i = 16; //field_77289_h
+    private Random j = new Random(); //j
+    public double c; //explosionX
+    public double d; //explosionY
+    public double e; //e
+    public Entity f; //exploder
+    public float g; //explosionSize
+    private World k; //worldObj
+
+    /** A list of ChunkPositions of blocks affected by this explosion */
+    public List h = new ArrayList(); //h
+    private Map l = new HashMap(); //field_77288_k
+    
+    @AsmagicReplaceMethod
+    public void a(boolean par1)
+    {
+        //BukkitForge start - Patch the class instance to being able to compile
+        Explosion newThis = null;
+        try {
+            newThis = (Explosion)Class.forName(this.getClass().getName()).cast(this);
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+        //BukkitForge end
+        
+        this.k.playSoundEffect(this.c, this.d, this.e, "random.explode", 4.0F, (1.0F + (this.k.rand.nextFloat() - this.k.rand.nextFloat()) * 0.2F) * 0.7F);
+
+        if (this.g >= 2.0F && this.b)
+        {
+            this.k.spawnParticle("hugeexplosion", this.c, this.d, this.e, 1.0D, 0.0D, 0.0D);
+        }
+        else
+        {
+            this.k.spawnParticle("largeexplode", this.c, this.d, this.e, 1.0D, 0.0D, 0.0D);
+        }
+
+        Iterator iterator;
+        ChunkPosition chunkposition;
+        int i;
+        int j;
+        int k;
+        int l;
+
+        if (this.b)
+        {
+            //BukkitForge start
+            if(EventFactory.onEntityExplode(this.h, this.k, this.f, this.c, this.d, this.e, this.g))
+            {
+                this.g = -1F;
+                return;
+            }
+            //BukkitForge end
+            iterator = this.h.iterator();
+
+            while (iterator.hasNext())
+            {
+                chunkposition = (ChunkPosition)iterator.next();
+                i = chunkposition.x;
+                j = chunkposition.y;
+                k = chunkposition.z;
+                l = this.k.getBlockId(i, j, k);
+
+                if (par1)
+                {
+                    double d0 = (double)((float)i + this.k.rand.nextFloat());
+                    double d1 = (double)((float)j + this.k.rand.nextFloat());
+                    double d2 = (double)((float)k + this.k.rand.nextFloat());
+                    double d3 = d0 - this.c;
+                    double d4 = d1 - this.d;
+                    double d5 = d2 - this.e;
+                    double d6 = (double)MathHelper.sqrt_double(d3 * d3 + d4 * d4 + d5 * d5);
+                    d3 /= d6;
+                    d4 /= d6;
+                    d5 /= d6;
+                    double d7 = 0.5D / (d6 / (double)this.g + 0.1D);
+                    d7 *= (double)(this.k.rand.nextFloat() * this.k.rand.nextFloat() + 0.3F);
+                    d3 *= d7;
+                    d4 *= d7;
+                    d5 *= d7;
+                    this.k.spawnParticle("explode", (d0 + this.c * 1.0D) / 2.0D, (d1 + this.d * 1.0D) / 2.0D, (d2 + this.e * 1.0D) / 2.0D, d3, d4, d5);
+                    this.k.spawnParticle("smoke", d0, d1, d2, d3, d4, d5);
+                }
+
+                if (l > 0)
+                {
+                    Block block = Block.blocksList[l];
+
+                    if (block.canDropFromExplosion(newThis)) //BukkitForge - this -> newThis
+                    {
+                        block.dropBlockAsItemWithChance(this.k, i, j, k, this.k.getBlockMetadata(i, j, k), 1.0F / this.g, 0);
+                    }
+
+                    this.k.setBlock(i, j, k, 0, 0, 3);
+                    block.onBlockDestroyedByExplosion(this.k, i, j, k, newThis); //BukkitForge - this -> newThis
+                }
+            }
+        }
+
+        if (this.a)
+        {
+            iterator = this.h.iterator();
+
+            while (iterator.hasNext())
+            {
+                chunkposition = (ChunkPosition)iterator.next();
+                i = chunkposition.x;
+                j = chunkposition.y;
+                k = chunkposition.z;
+                l = this.k.getBlockId(i, j, k);
+                int i1 = this.k.getBlockId(i, j - 1, k);
+
+                if (l == 0 && Block.opaqueCubeLookup[i1] && this.j.nextInt(3) == 0)
+                {
+                    this.k.setBlock(i, j, k, Block.fire.blockID);
+                }
+            }
+        }
+    }
+}

--- a/src/keepcalm/mods/bukkit/asm/replacements/WorldServer_BukkitForge.java
+++ b/src/keepcalm/mods/bukkit/asm/replacements/WorldServer_BukkitForge.java
@@ -1,0 +1,62 @@
+package keepcalm.mods.bukkit.asm.replacements;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import com.eoware.asm.asmagic.AsmagicReplaceMethod;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.packet.Packet60Explosion;
+import net.minecraft.util.Vec3;
+import net.minecraft.world.Explosion;
+import net.minecraft.world.WorldServer;
+
+public class WorldServer_BukkitForge 
+{
+    public List playerEntities = new ArrayList();
+    
+    //newExplosion
+    @AsmagicReplaceMethod
+    public Explosion a(Entity par1Entity, double par2, double par4, double par6, float par8, boolean par9, boolean par10)
+    {
+        //BukkitForge start - Patch the class instance to being able to compile
+        WorldServer newThis = null;
+        try {
+            newThis = (WorldServer)Class.forName(this.getClass().getName()).cast(this);
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+        //BukkitForge end
+        Explosion explosion = new Explosion(newThis, par1Entity, par2, par4, par6, par8); //BukkitForge - use newThis instead of this
+        explosion.isFlaming = par9;
+        explosion.isSmoking = par10;
+        explosion.doExplosionA();
+        explosion.doExplosionB(false);
+
+        if (!par10)
+        {
+            explosion.affectedBlockPositions.clear();
+        }
+        //BukkitForge start - if size is negative cancel
+        if (explosion.explosionSize < 0)
+            return explosion;
+        //BukkitForge end
+
+        Iterator iterator = this.playerEntities.iterator();
+
+        while (iterator.hasNext())
+        {
+            EntityPlayer entityplayer = (EntityPlayer)iterator.next();
+
+            if (entityplayer.getDistanceSq(par2, par4, par6) < 4096.0D)
+            {
+                ((EntityPlayerMP)entityplayer).playerNetServerHandler.sendPacketToPlayer(new Packet60Explosion(par2, par4, par6, par8, explosion.affectedBlockPositions, (Vec3)explosion.func_77277_b().get(entityplayer)));
+            }
+        }
+
+        return explosion;
+    }
+}

--- a/src/keepcalm/mods/bukkit/asm/transformers/BukkitAsmagicTransformer.java
+++ b/src/keepcalm/mods/bukkit/asm/transformers/BukkitAsmagicTransformer.java
@@ -27,7 +27,9 @@ public class BukkitAsmagicTransformer implements IClassTransformer {
         //addClassNameAndAlias(classes, "cpw.mods.fml.common.network.NetworkRegistry", null, NetworkRegistry_BukkitForge.class);
         addClassNameAndAlias(classes, "net.minecraft.network.NetServerHandler", "jh", NetServerHandler_BukkitForge.class);
         addClassNameAndAlias(classes, "net.minecraft.entity.EntityTracker", "it", EntityTracker_BukkitForge.class);
-
+        addClassNameAndAlias(classes, "net.minecraft.world.WorldServer", "iz", WorldServer_BukkitForge.class);
+        addClassNameAndAlias(classes, "net.minecraft.world.Explosion", "zw", Explosion_BukkitForge.class);
+        
         return classes;
     }
 
@@ -71,7 +73,6 @@ public class BukkitAsmagicTransformer implements IClassTransformer {
         {
             System.out.println( "Transforming " + s + " using " + classes.get(s) + " -- Size unchanged, likely not changed" );
         }
-
         return newClass;
     }
 

--- a/src/keepcalm/mods/events/EventFactory.java
+++ b/src/keepcalm/mods/events/EventFactory.java
@@ -1,16 +1,54 @@
 package keepcalm.mods.events;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import keepcalm.mods.bukkit.ToBukkit;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.event.entity.EntityExplodeEvent;
+
 import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 
 public class EventFactory {
-	public static boolean onBlockHarvested(World world, int x, int y, int z, Block block, int metadata, EntityPlayer entityPlayer) {
-		PlayerBreakBlockEvent ev = new PlayerBreakBlockEvent(world,x,y,z,block,metadata,entityPlayer);
-		MinecraftForge.EVENT_BUS.post(ev);
-		
-		
-		return ev.isCanceled();
-	}
+    public static boolean onBlockHarvested(World world, int x, int y, int z, Block block, int metadata, EntityPlayer entityPlayer) {
+        PlayerBreakBlockEvent ev = new PlayerBreakBlockEvent(world,x,y,z,block,metadata,entityPlayer);
+        MinecraftForge.EVENT_BUS.post(ev);
+        
+        
+        return ev.isCanceled();
+    }
+    
+    public static boolean onEntityExplode(List blocks, World world, Entity entity, double x, double y, double z, float strength)
+    {
+        org.bukkit.World bworld = ToBukkit.world(world);
+        org.bukkit.entity.Entity explode = entity == null ? null : ToBukkit.entity(entity);
+        Location location = new Location(bworld, x, y, z);
+
+        List<org.bukkit.block.Block> blockList = new ArrayList<org.bukkit.block.Block>();
+        for (int i1 = blocks.size() - 1; i1 >= 0; i1--) {
+            ChunkPosition cpos = (ChunkPosition) blocks.get(i1);
+            org.bukkit.block.Block block = bworld.getBlockAt(cpos.x, cpos.y, cpos.z);
+            if (block.getType() != org.bukkit.Material.AIR) {
+                blockList.add(block);
+            }
+        }
+
+        EntityExplodeEvent event = new EntityExplodeEvent(explode, location, blockList, strength);
+        Bukkit.getServer().getPluginManager().callEvent(event);
+        blocks.clear();
+
+        for (org.bukkit.block.Block block : event.blockList()) {
+            ChunkPosition coords = new ChunkPosition(block.getX(), block.getY(), block.getZ());
+            blocks.add(coords);
+        }
+
+        return event.isCancelled();
+    }
 }


### PR DESCRIPTION
This adds the support of Bukkits EntityExplodeEvent.
The implementation of this feature is a bit tricky, 
because you can't intercept an exploding Entity in Forge. 
There are simply no Forge-Events to do this. 
So you need to modify 2 Vanilla classes, to being able to call this event. 
The changes are reduced to the minimum and similar to the Bukkit-Implementation.
This allows for example WorldGuard to deny TNT explosions.
