### PR TITLE
Fix #535 to make plugin channels work as supposed. [WORLDEDIT]

### DIFF
--- a/src/keepcalm/mods/bukkit/asm/replacements/NetworkRegistry_BukkitForge.java
+++ b/src/keepcalm/mods/bukkit/asm/replacements/NetworkRegistry_BukkitForge.java
@@ -1,27 +1,30 @@
 package keepcalm.mods.bukkit.asm.replacements;
 
-
-import com.eoware.asm.asmagic.AsmagicClassProxy;
-import com.eoware.asm.asmagic.AsmagicAddMethod;
-import com.eoware.asm.asmagic.AsmagicMethodPublic;
 import com.eoware.asm.asmagic.AsmagicReplaceMethod;
 import com.google.common.collect.Sets;
 import cpw.mods.fml.common.network.IConnectionHandler;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.Player;
-import cpw.mods.fml.relauncher.Side;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.INetworkManager;
 import net.minecraft.network.NetServerHandler;
 import net.minecraft.network.packet.NetHandler;
+import net.minecraft.network.packet.Packet250CustomPayload;
 
+import java.util.List;
 import java.util.Set;
+
+import keepcalm.mods.bukkit.ToBukkit;
+import keepcalm.mods.bukkit.forgeHandler.ForgePacketHandler;
+
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
 
 public class NetworkRegistry_BukkitForge {
 
     private Set<IConnectionHandler> connectionHandlers = Sets.newLinkedHashSet();
-
+    
     private static final NetworkRegistry_BukkitForge INSTANCE = new NetworkRegistry_BukkitForge();
 
     public static NetworkRegistry_BukkitForge instance()
@@ -40,5 +43,56 @@ public class NetworkRegistry_BukkitForge {
 
     void generateChannelRegistration(EntityPlayer player, NetHandler netHandler, INetworkManager manager)
     {
+    }
+    
+    /* To intercept REGISTER packets */
+    @AsmagicReplaceMethod
+    private void handleRegistrationPacket(Packet250CustomPayload packet, Player player)
+    {
+        List<String> channels = extractChannelList(packet);
+        for (String channel : channels)
+        {
+            activateChannel(player, channel);
+            //BukkitForge start
+            if(Bukkit.getServer().getMessenger().getIncomingChannels().contains(channel))
+            {
+            	 ((CraftPlayer)ToBukkit.player((EntityPlayer)player)).addChannel(channel);
+            	 NetworkRegistry.instance().registerChannel(ForgePacketHandler.instance(), channel);
+            	 ForgePacketHandler.registerChannel(channel, (EntityPlayer)player);
+            }
+            //BukkitForge end
+        }
+    }
+    
+    /* To intercept UNREGISTER packets */
+    @AsmagicReplaceMethod
+    private void handleUnregistrationPacket(Packet250CustomPayload packet, Player player)
+    {
+        List<String> channels = extractChannelList(packet);
+        for (String channel : channels)
+        {
+            deactivateChannel(player, channel);
+            //BukkitForge start
+            if(Bukkit.getServer().getMessenger().getIncomingChannels().contains(channel))
+            {
+            	((CraftPlayer)ToBukkit.player((EntityPlayer)player)).removeChannel(channel);
+            }
+            //BukkitForge end
+        }
+    }
+    
+    private List<String> extractChannelList(Packet250CustomPayload packet)
+    {
+    	return null;
+    }
+    
+    void deactivateChannel(Player player, String channel)
+    {
+    	
+    }
+    
+    void activateChannel(Player player, String channel)
+    {
+    	
     }
 }

--- a/src/keepcalm/mods/bukkit/asm/transformers/BukkitAsmagicTransformer.java
+++ b/src/keepcalm/mods/bukkit/asm/transformers/BukkitAsmagicTransformer.java
@@ -24,7 +24,7 @@ public class BukkitAsmagicTransformer implements IClassTransformer {
         addClassNameAndAlias(classes, "net.minecraftforge.common.DimensionManager", null, DimensionManager_BukkitForge.class);
         //addClassNameAndAlias(classes, "net.minecraft.server.management.ServerConfigurationManager", "gu", ServerConfigurationManager_BukkitForge.class);
         //addClassNameAndAlias(classes, "cpw.mods.fml.common.network.FMLNetworkHandler", null, FMLNetworkHandler_BukkitForge.class);
-        //addClassNameAndAlias(classes, "cpw.mods.fml.common.network.NetworkRegistry", null, NetworkRegistry_BukkitForge.class);
+        addClassNameAndAlias(classes, "cpw.mods.fml.common.network.NetworkRegistry", null, NetworkRegistry_BukkitForge.class);
         addClassNameAndAlias(classes, "net.minecraft.network.NetServerHandler", "jh", NetServerHandler_BukkitForge.class);
         addClassNameAndAlias(classes, "net.minecraft.entity.EntityTracker", "it", EntityTracker_BukkitForge.class);
         addClassNameAndAlias(classes, "net.minecraft.world.WorldServer", "iz", WorldServer_BukkitForge.class);

--- a/src/keepcalm/mods/bukkit/forgeHandler/ForgePacketHandler.java
+++ b/src/keepcalm/mods/bukkit/forgeHandler/ForgePacketHandler.java
@@ -34,7 +34,7 @@ public class ForgePacketHandler implements IPacketHandler {
 	
 	public static HashMap<String,List<String>> listeningChannels = Maps.newHashMap();
 	
-	private static ForgePacketHandler INSTANCE;
+	private static ForgePacketHandler INSTANCE = null;
 	
 	public ForgePacketHandler() {
 		this.INSTANCE = this;
@@ -47,15 +47,10 @@ public class ForgePacketHandler implements IPacketHandler {
 			return; // nothing client-side here.
 		}
 		EntityPlayer fp = (EntityPlayer) player;
-		if (this.listeningChannels.values().contains(packet.channel) && this.listeningChannels.get(fp.username).contains(packet.channel)) {
-			((StandardMessenger)CraftServer.instance().getMessenger()).dispatchIncomingMessage(BukkitForgePlayerCache.getCraftPlayer((EntityPlayerMP) player), packet.channel, packet.data);
-			
-		}
-		
+		((StandardMessenger)CraftServer.instance().getMessenger()).dispatchIncomingMessage(BukkitForgePlayerCache.getCraftPlayer((EntityPlayerMP) player), packet.channel, packet.data);
 	}
 	
 	public static void registerChannel(String chan, EntityPlayer player) {
-		
 		if (!listeningChannels.containsKey(player.username)) {
 			listeningChannels.put(player.username, new ArrayList<String>());
 		}
@@ -66,4 +61,10 @@ public class ForgePacketHandler implements IPacketHandler {
 		}
 	}
 
+	public static ForgePacketHandler instance()
+	{
+		if(INSTANCE == null)
+			INSTANCE = new ForgePacketHandler();
+		return INSTANCE;
+	}
 }

--- a/src/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/src/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -832,16 +832,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player, CommandSend
 	public void sendPluginMessage(Plugin source, String channel, byte[] message) {
 		StandardMessenger.validatePluginMessage(server.getMessenger(), source, channel, message);
 		if (getHandle().playerNetServerHandler == null) return;
-
 		if (channels.contains(channel)) {
 			Packet250CustomPayload packet = new Packet250CustomPayload();
 			packet.channel = channel;
 			packet.length = message.length;
 			packet.data = message;
-			FMLNetworkHandler.handlePacket250Packet(packet, 
-					getHandle().playerNetServerHandler.netManager, 
-					getHandle().playerNetServerHandler);
-			//getHandle().playerNetServerHandler.sendPacketToPlayer(packet);
+			getHandle().playerNetServerHandler.sendPacketToPlayer(packet);
 		}
 	}
 

--- a/src/org/bukkit/plugin/messaging/StandardMessenger.java
+++ b/src/org/bukkit/plugin/messaging/StandardMessenger.java
@@ -5,11 +5,16 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import keepcalm.mods.bukkit.forgeHandler.ForgePacketHandler;
+
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
+
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.relauncher.Side;
 
 /**
  * Standard implementation to {@link Messenger}
@@ -183,6 +188,8 @@ public class StandardMessenger implements Messenger {
         }
 
         addToOutgoing(plugin, channel);
+        NetworkRegistry.instance().registerChannel(ForgePacketHandler.instance(), channel);
+        NetworkRegistry.instance().registerChannel(ForgePacketHandler.instance(), channel, Side.SERVER);
     }
 
     public void unregisterOutgoingPluginChannel(Plugin plugin, String channel) {
@@ -217,7 +224,8 @@ public class StandardMessenger implements Messenger {
         PluginMessageListenerRegistration result = new PluginMessageListenerRegistration(this, plugin, channel, listener);
 
         addToIncoming(result);
-
+        NetworkRegistry.instance().registerChannel(ForgePacketHandler.instance(), channel);
+        NetworkRegistry.instance().registerChannel(ForgePacketHandler.instance(), channel, Side.SERVER);
         return result;
     }
 


### PR DESCRIPTION
They are now correctly send to the client and also on the forge-server side acknowledged.
This is a proper version of my last workaround: bdbae709f7f98fc7aa9da5a16edacab2fb235754
WorldGuard CUI for example works with this fix.
The plugin channels seem to work now.
