### PR TITLE
Implement AIR Clicks out of range [Thor, VoxelSniper?]

### DIFF
--- a/src/keepcalm/mods/bukkit/asm/replacements/Packet18Animation_BukkitForge.java
+++ b/src/keepcalm/mods/bukkit/asm/replacements/Packet18Animation_BukkitForge.java
@@ -1,0 +1,32 @@
+package keepcalm.mods.bukkit.asm.replacements;
+
+import org.bukkit.event.block.Action;
+
+import keepcalm.mods.events.EventFactory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.packet.NetHandler;
+import net.minecraft.network.packet.Packet18Animation;
+
+import com.eoware.asm.asmagic.AsmagicReplaceMethod;
+
+public class Packet18Animation_BukkitForge 
+{
+    //processPacket
+    @AsmagicReplaceMethod
+    public void a(NetHandler par1NetHandler)
+    {
+        //BukkitForge start
+        Packet18Animation newThis = null;
+        try {
+            newThis = (Packet18Animation)Class.forName(this.getClass().getName()).cast(this);
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+        ItemStack stack = par1NetHandler.getPlayer().getHeldItem();
+        //@see Bukkit implementation at CraftEventFactory: return callPlayerInteractEvent(who, action, 0, 256, 0, 0, itemstack);
+        if(EventFactory.onPlayerInteract(par1NetHandler.getPlayer(), Action.LEFT_CLICK_AIR, stack, 0, 256, 0, 0))
+            return;
+        //BukkitForge end
+        par1NetHandler.handleAnimation(newThis);
+    }
+}

--- a/src/keepcalm/mods/bukkit/asm/transformers/BukkitAsmagicTransformer.java
+++ b/src/keepcalm/mods/bukkit/asm/transformers/BukkitAsmagicTransformer.java
@@ -29,6 +29,7 @@ public class BukkitAsmagicTransformer implements IClassTransformer {
         addClassNameAndAlias(classes, "net.minecraft.entity.EntityTracker", "it", EntityTracker_BukkitForge.class);
         addClassNameAndAlias(classes, "net.minecraft.world.WorldServer", "iz", WorldServer_BukkitForge.class);
         addClassNameAndAlias(classes, "net.minecraft.world.Explosion", "zw", Explosion_BukkitForge.class);
+        addClassNameAndAlias(classes, "net.minecraft.network.packet.Packet18Animation", "ct", Packet18Animation_BukkitForge.class);
         
         return classes;
     }

--- a/src/keepcalm/mods/events/EventFactory.java
+++ b/src/keepcalm/mods/events/EventFactory.java
@@ -7,11 +7,17 @@ import keepcalm.mods.bukkit.ToBukkit;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.craftbukkit.CraftChunk;
+import org.bukkit.craftbukkit.block.CraftBlock;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
@@ -49,6 +55,20 @@ public class EventFactory {
             blocks.add(coords);
         }
 
+        return event.isCancelled();
+    }
+    
+    public static boolean onPlayerInteract(EntityPlayer who, Action action, ItemStack item, int x, int y, int z, int notchFace)
+    {
+        Player player = ToBukkit.player(who);
+        PlayerInteractEvent event = new PlayerInteractEvent(
+            player,
+            action,
+            ToBukkit.itemStack(item),
+            player.getWorld().getBlockAt(x, y, z),
+            CraftBlock.notchToBlockFace(notchFace)
+        );
+        Bukkit.getServer().getPluginManager().callEvent(event);
         return event.isCancelled();
     }
 }


### PR DESCRIPTION
Implements the LEFT_CLICK_AIR Action Type of the PlayerInteractionEvent to make plugins like VoxelSniper and CommandBooks Thor work.
This is being called if there is just an armswing, after actions of the player outside of the sight range.
