### PR TITLE
Use correct chunk coordinates to get the real block Chunk

### DIFF
--- a/src/keepcalm/mods/bukkit/forgeHandler/ForgeEventHandler.java
+++ b/src/keepcalm/mods/bukkit/forgeHandler/ForgeEventHandler.java
@@ -280,7 +280,7 @@ public class ForgeEventHandler {
 				}
 
 				final CraftPlayer thePlayer = BukkitForgePlayerCache.getCraftPlayer(forgePlayerMP);
-				final CraftBlock beforeBlock = new CraftBlock(new CraftChunk(ev.entity.worldObj.getChunkFromBlockCoords(ev.x, ev.y)), blockX, blockY, blockZ);
+				final CraftBlock beforeBlock = new CraftBlock(new CraftChunk(ev.entity.worldObj.getChunkFromBlockCoords(blockX, blockZ)), blockX, blockY, blockZ);
 				WorldServer world = (WorldServer) ev.entity.worldObj;
 				int minX = world.getSpawnPoint().posX;
 				int minY = world.getSpawnPoint().posY;


### PR DESCRIPTION
Fixes #593 Thanks to @nallar
Explanation shouldnt be needed. Simply wrong coordinates to get the chunk of an block...
