### PR TITLE
Non-blocked Explosions Fix: No Exception

### DIFF
--- a/src/keepcalm/mods/bukkit/asm/replacements/WorldServer_BukkitForge.java
+++ b/src/keepcalm/mods/bukkit/asm/replacements/WorldServer_BukkitForge.java
@@ -16,7 +16,7 @@ import net.minecraft.world.WorldServer;
 
 public class WorldServer_BukkitForge 
 {
-    public List playerEntities = new ArrayList();
+    public List h = new ArrayList();
     
     //newExplosion
     @AsmagicReplaceMethod
@@ -45,7 +45,7 @@ public class WorldServer_BukkitForge
             return explosion;
         //BukkitForge end
 
-        Iterator iterator = this.playerEntities.iterator();
+        Iterator iterator = this.h.iterator();
 
         while (iterator.hasNext())
         {


### PR DESCRIPTION
Actually make non blocked explosions work again.
This was prevented due an missing field obfuscation...
Simple fix.
