### PR TITLE
Fix CraftItemStack to be able to set durability/amount of items [CommandBoook]

### DIFF
--- a/src/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+++ b/src/org/bukkit/craftbukkit/inventory/CraftItemStack.java
@@ -83,4 +83,14 @@ public class CraftItemStack extends ItemStack {
 	public static ItemStack asNewCraftStack(Item item, int j) {
 		return new CraftItemStack(new net.minecraft.item.ItemStack(item, j));
 	}
+	
+	public void setAmount(int amount) {
+		super.setAmount(amount);
+		this.item.stackSize = amount > getMaxStackSize() ? getMaxStackSize() : amount;
+	}
+	
+	public void setDurability(final short durability) {
+        super.setDurability(durability);
+		this.item.setItemDamage(durability);
+    }
 }


### PR DESCRIPTION
This allows CraftItemStack to set durability and the amount of items, which else would be ignored.
This fixes for example /more command of CommandBook.
