### PR TITLE
Cleanup loggers on shutdown (ErrorFix, Cleanup)

### DIFF
--- a/src/keepcalm/mods/bukkit/forgeHandler/commands/CraftCommandStop.java
+++ b/src/keepcalm/mods/bukkit/forgeHandler/commands/CraftCommandStop.java
@@ -37,7 +37,6 @@ public class CraftCommandStop extends CommandBase {
 	
 	@Override
 	public void processCommand(ICommandSender var1, String[] var2) {
-		BukkitContainer.bServer.shutdown();
 		(new CommandServerStop()).processCommand(var1, var2);
 	}
 


### PR DESCRIPTION
Only allow bukkit to shutdown ONCE!
Remove redudant BukkitContainer shutdown (anyways called by forge shutdown hook)
Simple cleanup and error prevention.
